### PR TITLE
Introduces threshold for the amount of matches that will be considered when validating the address

### DIFF
--- a/lib/alexa-skill/intent-handlers/provide-address.js
+++ b/lib/alexa-skill/intent-handlers/provide-address.js
@@ -49,6 +49,10 @@ function handleProvideAddressIntent(event, response) {
                     verificationResult = JSON.parse(verificationResult);
 
                     if (verificationResult.status && verificationResult.status == 'OK') {
+                        if (verificationResult.results.length > 3) {
+                            verificationResult.results = verificationResult.results.splice(0, config.addressVerificationParams.maxMatches);
+                        }
+
                         _.forEach(verificationResult.results, function (matchingAddress) {
                             let verifiedAddress = {};
 


### PR DESCRIPTION
When the address is not specific enough, Google might return an enormous amonut of addresses. We're limiting it to a configurable number, after which we consider the address wasn't specific enough and we re-promt the user to provide the address once more.